### PR TITLE
Fix: Resolve Android build failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 # firebase
 firebase-debug.log
 firestore-debug.log
+android-sdk/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
     defaultConfig {
         applicationId "com.studysentinel.app"
         minSdkVersion 23
-        targetSdkVersion 34
-        compileSdkVersion 34
+        targetSdkVersion 35
+        compileSdkVersion 35
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,4 +22,3 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 
 # Use Android Studio's embedded JDK
-org.gradle.java.home=C:\\Program Files\\Android\\Android Studio\\jbr

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,7 +1,7 @@
 ext {
     minSdkVersion = 23
-    compileSdkVersion = 34
-    targetSdkVersion = 34
+    compileSdkVersion = 35
+    targetSdkVersion = 35
     androidxActivityVersion = '1.9.2'
     androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'


### PR DESCRIPTION
The Android build was failing due to several issues:
- A hardcoded Windows path in gradle.properties.
- Dependencies requiring a newer Android SDK version (35).

This commit resolves these issues by:
- Removing the hardcoded org.gradle.java.home property.
- Updating the compileSdkVersion and targetSdkVersion from 34 to 35.
- Adding the Android/ directory to .gitignore to avoid committing local SDK installations.

With these changes, the Android project now builds successfully and all unit tests pass.