### PR TITLE
fix(tests): Fix failing tests for PlanItemRenderer

### DIFF
--- a/__mocks__/lucide-react.js
+++ b/__mocks__/lucide-react.js
@@ -65,6 +65,8 @@ const iconNames = [
   'Zap',
   'Memory',
   'Target',
+  'Infinity',
+  'Timer',
   'TrendingUp',
   'BarChart3',
   'PieChart',

--- a/src/components/plans/__tests__/plan-item-renderer-task-card.test.tsx
+++ b/src/components/plans/__tests__/plan-item-renderer-task-card.test.tsx
@@ -114,11 +114,11 @@ describe('PlanItemRenderer (Task-Card Variant)', () => {
     const menuButton = screen.getByRole('button');
     await user.click(menuButton);
 
-    expect(screen.getByText('Start Timer')).toBeInTheDocument();
-    expect(screen.getByText('Mark Complete')).toBeInTheDocument();
-    expect(screen.getByText('Edit')).toBeInTheDocument();
-    expect(screen.getByText('Push to Next Day')).toBeInTheDocument();
-    expect(screen.getByText('Archive')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /start timer/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /mark complete/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /edit/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /push to next day/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /archive/i })).toBeInTheDocument();
   });
 
   it('handles task completion with confetti and toast', async () => {
@@ -179,7 +179,7 @@ describe('PlanItemRenderer (Task-Card Variant)', () => {
     await user.click(menuButton);
 
     expect(screen.getByRole('menuitem', { name: /restore/i })).toBeInTheDocument();
-    expect(screen.queryByRole('menuitem', { name: /archive/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /^archive$/i })).not.toBeInTheDocument();
   });
 
   it('handles task restoration with toast', async () => {


### PR DESCRIPTION
The tests in `src/components/plans/__tests__/plan-item-renderer-task-card.test.tsx` were failing due to two issues:
1. An incomplete mock for the `lucide-react` library, which caused an "Element type is invalid" error when rendering icons that were not in the mock.
2. Ambiguous queries in the tests that would find multiple elements in the DOM, causing tests to fail.

This commit addresses these issues by:
- Adding the missing `Infinity` and `Timer` icons to the `lucide-react` mock.
- Updating the test queries to be more specific, using `getByRole` with more precise names, to avoid ambiguity.

The test file was not deleted as it is a modern and relevant test that now passes and provides valuable coverage for the `PlanItemRenderer` component.